### PR TITLE
chore: 인증 정보 swagger에서 별도 표기, login response 변경

### DIFF
--- a/asset_management/app/auth/router.py
+++ b/asset_management/app/auth/router.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Header, status, Response
 from sqlalchemy.orm import Session
-from asset_management.app.auth.schemas import UserSignin, TokenResponse
+from asset_management.app.auth.schemas import LoginResponse, UserSignin, TokenResponse
 from asset_management.app.auth.services import AuthServices
 from asset_management.app.auth.utils import (
   issue_token,
@@ -19,9 +19,9 @@ blocked_token = {}
 @router.post("/login", status_code=status.HTTP_200_OK)
 def login(
   request: UserSignin, auth_service: Annotated[AuthServices, Depends()]
-) -> TokenResponse:
-  token = auth_service.login_user(request.email, request.password)
-  return TokenResponse(**token)
+) -> LoginResponse:
+  login_info = auth_service.login_user(request.email, request.password)
+  return LoginResponse(**login_info)
 
 
 @router.get("/refresh", status_code=status.HTTP_200_OK)

--- a/asset_management/app/auth/schemas.py
+++ b/asset_management/app/auth/schemas.py
@@ -7,3 +7,7 @@ class UserSignin(BaseModel):
 class TokenResponse(BaseModel):
     access_token: str
     refresh_token: str
+class LoginResponse(BaseModel):
+    user_name: str
+    user_type: int
+    tokens: TokenResponse

--- a/asset_management/app/auth/services.py
+++ b/asset_management/app/auth/services.py
@@ -26,7 +26,9 @@ class AuthServices:
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Invalid email or password",
       )
-    return self.issue_token(user.id)
+    user_name = user.name
+    user_type = user.is_admin
+    return {"user_name": user_name, "user_type": user_type, "tokens": self.issue_token(user.id)}
 
   def refresh_user_token(self, refresh_token: str):
     user_id = verify_token(refresh_token, AUTH_SETTINGS.REFRESH_TOKEN_SECRET, "refresh")

--- a/asset_management/app/auth/utils.py
+++ b/asset_management/app/auth/utils.py
@@ -6,6 +6,7 @@ from authlib.jose.errors import JoseError
 from fastapi import Depends, Header, HTTPException, status
 from typing import Annotated
 import hashlib
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 
 def issue_token(user_id: int) -> str:
@@ -31,14 +32,11 @@ def issue_token(user_id: int) -> str:
 
   return {"access_token": access_token, "refresh_token": refresh_token}
 
-def get_header_token(authorization: Annotated[str | None, Header()] = None) -> str:
-  if not authorization or not authorization.startswith("Bearer "):
-    raise HTTPException(
-      status_code=status.HTTP_401_UNAUTHORIZED,
-      detail="Invalid authorization header",
-      headers={"WWW-Authenticate": "Bearer"},
-    )
-  return authorization.split(" ")[1]
+# Security scheme for Swagger UI
+security = HTTPBearer()
+
+def get_header_token(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
+  return credentials.credentials
 
 def login_with_header(token: Annotated[str | None, Depends(get_header_token)] = None):
   return verify_token(token, AUTH_SETTINGS.ACCESS_TOKEN_SECRET, "access")


### PR DESCRIPTION
- swagger 우측 상단에 jwt 토큰을 별도로 입력하게 변경했습니다.
- login response를 맹준호님 요청대로 변경했습니다. (이름과 권한 함께 응답)
- 테스트 코드를 수정했습니다.