### PR TITLE
fix: 운영자 로그인 시 내 동아리 조회 엔드포인트 추가

### DIFF
--- a/asset_management/app/admin/schemas.py
+++ b/asset_management/app/admin/schemas.py
@@ -54,3 +54,9 @@ class ClubCodeUpdateRequest(BaseModel):
 class ClubCodeUpdateResponse(BaseModel):
     club_id: int
     club_code: str
+
+
+class AdminMyClubResponse(BaseModel):
+    club_id: int
+    club_name: str
+    club_code: str

--- a/tests/test_clubs.py
+++ b/tests/test_clubs.py
@@ -106,3 +106,33 @@ def test_admin_update_club_code(client):
     club_response = client.get(f"/api/clubs/{club_id}")
     assert club_response.status_code == 200
     assert club_response.json()["club_code"] == "UPDATED1"
+
+
+def test_admin_get_my_club(client):
+    admin_payload = {
+        "name": "Admin My Club",
+        "email": "myclub_admin@example.com",
+        "password": "strongpassword",
+        "club_name": "My Club",
+        "club_description": "Test club for my-club endpoint",
+    }
+    signup_response = client.post("/api/admin/signup", json=admin_payload)
+    assert signup_response.status_code == 201
+    admin_data = signup_response.json()
+
+    login_response = client.post(
+        "/api/auth/login",
+        json={"email": admin_payload["email"], "password": admin_payload["password"]},
+    )
+    assert login_response.status_code == 200
+    token = login_response.json()["tokens"]["access_token"]
+
+    my_club_response = client.get(
+        "/api/admin/my-club",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert my_club_response.status_code == 200
+    my_club_data = my_club_response.json()
+    assert my_club_data["club_id"] == admin_data["club_id"]
+    assert my_club_data["club_name"] == admin_data["club_name"]
+    assert my_club_data["club_code"] == admin_data["club_code"]


### PR DESCRIPTION
- 로그인한 운영자 기준으로 내 동아리를 조회하는 전용 엔드포인트가 없어서, 프론트가 전체 클럽 목록 중 첫 번째를 사용하는 구조일 가능성이 큼
- 첫 번째 동아리가 테스트 동아리라서 문제가 있었음
- 운영자 전용 GET/api/admin/my-club 엔드포인트 추가로 로그인한 운영자의 클럽을 직접 조회 가능