### PR TITLE
feat: 자산 사진 업로드 및 조회 기능 추가

### DIFF
--- a/asset_management/app/assets/models.py
+++ b/asset_management/app/assets/models.py
@@ -26,7 +26,6 @@ class Asset(Base):
 
     club_id: Mapped[int] = mapped_column(ForeignKey("club.id"), nullable=False)
     category_id: Mapped[Optional[int]] = mapped_column(ForeignKey("category.id"), nullable=True)
-    # picture_id: Mapped[Optional[int]] = mapped_column(ForeignKey("picture.id"), nullable=True)
 
     # Relationships
     club: Mapped["Club"] = relationship(back_populates="assets")
@@ -34,13 +33,6 @@ class Asset(Base):
     schedules: Mapped[List["Schedule"]] = relationship(back_populates="asset")
     favorites: Mapped[List["Favorite"]] = relationship(back_populates="asset")
     statistics: Mapped[Optional["Statistic"]] = relationship(back_populates="asset", uselist=False)
-    # main_picture: Mapped[Optional["Picture"]] = relationship(
-    #     foreign_keys=[picture_id]
-    # )
-    # pictures: Mapped[List["Picture"]] = relationship(
-    #     back_populates="asset",
-    #     foreign_keys="[Picture.assets_id]"
-    # )
     pictures: Mapped[List["Picture"]] = relationship(
         back_populates="asset",
         cascade="all, delete-orphan"

--- a/asset_management/app/assets/router.py
+++ b/asset_management/app/assets/router.py
@@ -4,8 +4,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Header, status, Response, File, UploadFile
 from asset_management.app.assets.schemas import AssetCreateRequest, AssetResponse, AssetUpdateRequest, ImportResponse
 from asset_management.app.assets.services import AssetService
-# from asset_management.app.assets.utils import (
-# )
+from asset_management.app.picture.services import PictureService
 
 from asset_management.app.auth.dependencies import get_current_user
 from asset_management.app.user.models import User
@@ -64,3 +63,13 @@ def export_assets(
 def list_assets(club_id: int, asset_service: AssetService = Depends(AssetService)) -> list[AssetResponse]:
   assets = asset_service.list_assets_for_club(club_id)
   return assets
+
+
+@router.get("/{asset_id}/pictures", status_code=status.HTTP_200_OK)
+def get_asset_pictures(
+    asset_id: int,
+    picture_service: Annotated[PictureService, Depends()],
+):
+    """특정 asset의 모든 사진 메타데이터 목록을 가져옵니다."""
+    pictures = picture_service.list_pictures_by_asset(asset_id)
+    return pictures

--- a/asset_management/app/picture/models.py
+++ b/asset_management/app/picture/models.py
@@ -1,7 +1,8 @@
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING
-from sqlalchemy import Integer, DateTime, ForeignKey, String, Boolean
+from typing import TYPE_CHECKING, Optional
+from sqlalchemy import Integer, DateTime, ForeignKey, String, Boolean, func, LargeBinary
+from sqlalchemy.dialects.mysql import LONGBLOB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.dialects.postgresql import UUID
 from asset_management.database.common import Base
@@ -16,13 +17,18 @@ class Picture(Base):
     __tablename__ = "picture"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    date: Mapped[datetime] = mapped_column(DateTime, nullable=False)
-    assets_id: Mapped[int] = mapped_column(ForeignKey("assets.id"), nullable=False)
+    date: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=func.now())
+    asset_id: Mapped[int] = mapped_column(ForeignKey("assets.id"), nullable=False)
     is_main: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     user_id: Mapped[str] = mapped_column(String(36), ForeignKey("user.id"), nullable=False)
-    category_id: Mapped[int] = mapped_column(ForeignKey("category.id"), nullable=False)
+    category_id: Mapped[Optional[int]] = mapped_column(ForeignKey("category.id"), nullable=True)
+
+    data: Mapped[bytes] = mapped_column(LargeBinary().with_variant(LONGBLOB, "mysql"), nullable=False)
+    content_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    size: Mapped[int] = mapped_column(Integer, nullable=False)
 
     # Relationships
     asset: Mapped["Asset"] = relationship(back_populates="pictures")
     user: Mapped["User"] = relationship(back_populates="uploaded_pictures")
-    category: Mapped["Category"] = relationship(back_populates="pictures")
+    category: Mapped[Optional["Category"]] = relationship(back_populates="pictures")

--- a/asset_management/app/picture/repositories.py
+++ b/asset_management/app/picture/repositories.py
@@ -1,0 +1,41 @@
+from sqlalchemy import select
+from typing import Annotated
+from fastapi import Depends
+from sqlalchemy.orm import Session
+from asset_management.app.picture.models import Picture
+from asset_management.database.session import get_session
+
+
+
+class PictureRepository:
+    def __init__(self, session: Annotated[Session, Depends(get_session)]) -> None:
+        self.session = session
+
+    def create_picture(self, picture: Picture) -> Picture:
+        self.session.add(picture)
+        self.session.commit()
+        self.session.refresh(picture)
+        return picture
+    
+    def get_picture_by_id(self, picture_id: int) -> Picture | None:
+        pictureLoc = select(Picture).where(Picture.id == picture_id)
+        return self.session.scalar(pictureLoc)
+    
+    def get_pictures_by_asset(self, asset_id: int) -> list[Picture]:
+        picturesLoc = select(Picture).where(Picture.asset_id == asset_id)
+        return self.session.scalars(picturesLoc).all()
+    
+    def clear_main_picture_by_asset(self, asset_id: int) -> None:
+        picturesLoc = select(Picture).where(Picture.asset_id == asset_id, Picture.is_main == True)
+        main_pictures = self.session.scalars(picturesLoc).all()
+        for pic in main_pictures:
+            pic.is_main = False
+        self.session.commit()
+
+    def get_main_picture_by_asset(self, asset_id: int) -> Picture | None:
+        pictureLoc = select(Picture).where(Picture.asset_id == asset_id, Picture.is_main == True)
+        return self.session.scalar(pictureLoc)
+    
+    def delete_picture(self, picture: Picture) -> None:
+        self.session.delete(picture)
+        self.session.commit()

--- a/asset_management/app/picture/router.py
+++ b/asset_management/app/picture/router.py
@@ -1,0 +1,22 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Header, status, Response, File, UploadFile
+from asset_management.app.picture.services import PictureService
+
+router = APIRouter(prefix="/pictures", tags=["pictures"])
+
+@router.get("/{picture_id}", status_code=status.HTTP_200_OK)
+def get_picture(
+    picture_id: int,
+    picture_service: Annotated[PictureService, Depends()],
+) -> Response:
+    
+    """특정 사진을 가져옵니다."""
+    picture = picture_service.get_picture_model(picture_id)
+    return Response(
+        content=picture.data,
+        media_type=picture.content_type,
+        headers={
+            "Cache-Control": "public, max-age=86400"
+        }
+    )

--- a/asset_management/app/picture/schemas.py
+++ b/asset_management/app/picture/schemas.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+class PictureResponse(BaseModel):
+    id: int
+    date: datetime
+    asset_id: int
+    is_main: bool
+    user_id: str
+    
+    content_type: str
+    filename: str
+    size: int
+
+    class Config:
+        from_attributes = True
+
+class PictureCreateRequest(BaseModel):
+    asset_id: int
+    is_main: Optional[bool] = False

--- a/asset_management/app/picture/services.py
+++ b/asset_management/app/picture/services.py
@@ -1,0 +1,111 @@
+from typing import Annotated, List
+
+from fastapi import Depends, UploadFile, HTTPException
+from asset_management.app.picture.repositories import PictureRepository
+from asset_management.app.picture.schemas import PictureResponse, PictureCreateRequest
+from asset_management.app.picture.models import Picture
+
+
+class PictureService:
+    def __init__(
+        self,
+        picture_repository: Annotated[PictureRepository, Depends()],
+    ) -> None:
+        self.picture_repository = picture_repository
+
+    async def upload_picture(
+        self, user_id: int, file: UploadFile, picture_request: PictureCreateRequest
+    ) -> PictureResponse:
+        
+        data = await file.read()
+
+        if file.content_type not in {"image/jpeg", "image/png", "image/webp"}:
+            raise HTTPException(status_code=400, detail="Unsupported image type")
+
+        if len(data) > 5 * 1024 * 1024:
+            raise HTTPException(status_code=400, detail="File too large")
+
+        if picture_request.is_main:
+            self.picture_repository.clear_main_picture_by_asset(picture_request.asset_id)
+
+        new_picture = Picture(
+            asset_id=picture_request.asset_id,
+            is_main=picture_request.is_main,
+            user_id=user_id,
+            data=data,
+            content_type=file.content_type,
+            filename=file.filename or "upload",
+            size=len(data)            
+        )
+
+        self.picture_repository.create_picture(new_picture)
+
+        return PictureResponse(
+            id=new_picture.id,
+            date=new_picture.date,
+            asset_id=new_picture.asset_id,
+            is_main=new_picture.is_main,
+            user_id=new_picture.user_id,
+            content_type=new_picture.content_type,
+            filename=new_picture.filename,
+            size=new_picture.size,
+        )
+
+    def get_picture(self, picture_id: int) -> PictureResponse:
+        picture = self.picture_repository.get_picture_by_id(picture_id)
+        if picture is None:
+            raise HTTPException(status_code=404, detail="Picture not found")
+
+        return PictureResponse(
+            id=picture.id,
+            date=picture.date,
+            asset_id=picture.asset_id,
+            is_main=picture.is_main,
+            user_id=picture.user_id,
+            content_type=picture.content_type,
+            filename=picture.filename,
+            size=picture.size,
+        )
+    
+    def get_picture_model(self, picture_id: int) -> Picture:
+        picture = self.picture_repository.get_picture_by_id(picture_id)
+        if picture is None:
+            raise HTTPException(status_code=404, detail="Picture not found")
+        return picture
+
+
+    def delete_picture(self, picture_id: int) -> None:
+
+        picture = self.picture_repository.get_picture_by_id(picture_id)
+        if picture is None:
+            raise HTTPException(status_code=404, detail="Picture not found")
+        
+        self.picture_repository.delete_picture(picture)
+
+    def list_pictures_by_asset(self, asset_id: int) -> List[PictureResponse]:
+        pictures = self.picture_repository.get_pictures_by_asset(asset_id)
+        return [
+            PictureResponse(
+                id=picture.id,
+                date=picture.date,
+                asset_id=picture.asset_id,
+                is_main=picture.is_main,
+                user_id=picture.user_id,
+                content_type=picture.content_type,
+                filename=picture.filename,
+                size=picture.size,
+            )
+            for picture in pictures
+        ]
+    
+    def set_main_picture(self, asset_id: int, picture_id: int) -> None:
+        picture = self.picture_repository.get_picture_by_id(picture_id)
+        if picture is None or picture.asset_id != asset_id:
+            raise HTTPException(status_code=404, detail="Picture not found for the given asset")
+
+        self.picture_repository.clear_main_picture_by_asset(asset_id)
+
+        picture.is_main = True
+        self.picture_repository.session.commit()
+
+    

--- a/asset_management/main.py
+++ b/asset_management/main.py
@@ -11,6 +11,7 @@ from asset_management.app.club_member.router import router as club_member_router
 from asset_management.app.schedule.router import router as schedule_router
 from asset_management.app.rental.router import router as rental_router
 from asset_management.app.statistics.router import router as statistics_router
+from asset_management.app.picture.router import router as pictuer_router
 
 app = FastAPI(title="Asset Management API")
 
@@ -40,3 +41,4 @@ app.include_router(club_member_router, prefix="/api")
 app.include_router(schedule_router, prefix="/api")
 app.include_router(rental_router, prefix="/api")
 app.include_router(statistics_router, prefix="/api")
+app.include_router(pictuer_router, prefix="/api")

--- a/tests/test_picture.py
+++ b/tests/test_picture.py
@@ -1,0 +1,266 @@
+"""Picture 업로드/조회/목록/대표설정/삭제 기능 테스트"""
+import pytest
+from io import BytesIO
+from fastapi.testclient import TestClient
+
+
+def _fake_jpeg_bytes() -> bytes:
+    """
+    간단한 JPEG 헤더 + 더미 데이터.
+    실제 디코딩 목적이 아니라 업로드/저장/반환 흐름 테스트용.
+    """
+    return b"\xFF\xD8\xFF\xE0" + b"JFIF" + b"\x00" * 64 + b"\xFF\xD9"
+
+
+@pytest.fixture(scope="function")
+def admin_club(client: TestClient, db_session):
+    """Create a club with admin via admin signup"""
+    admin_signup_payload = {
+        "name": "pictureadmin",
+        "email": "pictureadmin@example.com",
+        "password": "adminpass123",
+        "club_name": "Picture Test Club",
+        "club_description": "Test club for pictures",
+        "location_lat": 37_500_000,
+        "location_lng": 127_000_000,
+    }
+    response = client.post(
+        "/api/admin/signup",
+        json=admin_signup_payload,
+    )
+    assert response.status_code == 201, response.text
+    data = response.json()
+    return {
+        "club_id": data["club_id"],
+        "admin_user_id": data["id"],
+        "admin_email": admin_signup_payload["email"],
+        "admin_password": admin_signup_payload["password"],
+    }
+
+
+@pytest.fixture(scope="function")
+def admin_token(client: TestClient, admin_club):
+    """Get authentication token for admin"""
+    response = client.post(
+        "/api/auth/login",
+        json={"email": admin_club["admin_email"], "password": admin_club["admin_password"]},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["tokens"]["access_token"]
+
+
+@pytest.fixture(scope="function")
+def test_asset(client: TestClient, admin_token: str, admin_club: dict):
+    """Create a test asset"""
+    asset_payload = {
+        "name": "Test Camera",
+        "description": "Canon EOS R5",
+        "category_id": None,
+        "quantity": 3,
+        "location": "Storage Room A",
+        "club_id": admin_club["club_id"],
+    }
+    response = client.post(
+        "/api/admin/assets",
+        json=asset_payload,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 201, f"Failed to create asset: {response.text}"
+    return response.json()
+
+
+@pytest.fixture(scope="function")
+def uploaded_picture(client: TestClient, admin_token: str, test_asset: dict):
+    """Upload a picture and return PictureResponse"""
+    files = {
+        "file": ("test.jpg", BytesIO(_fake_jpeg_bytes()), "image/jpeg")
+    }
+    response = client.post(
+        f"/api/admin/assets/{test_asset['id']}/pictures",
+        files=files,
+        params={"is_main": "true"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code in [201, 200], response.text
+    data = response.json()
+    assert "id" in data
+    return data
+
+
+def test_upload_picture_success(client: TestClient, admin_token: str, test_asset: dict):
+    """Test successful picture upload"""
+    files = {
+        "file": ("test.jpg", BytesIO(_fake_jpeg_bytes()), "image/jpeg")
+    }
+    response = client.post(
+        f"/api/admin/assets/{test_asset['id']}/pictures",
+        files=files,
+        params={"is_main": "false"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code in [201, 200], response.text
+    data = response.json()
+    assert data["asset_id"] == test_asset["id"]
+    assert data["content_type"].startswith("image/")
+    assert data["filename"] == "test.jpg"
+    assert data["size"] > 0
+
+
+def test_upload_picture_unsupported_type(client: TestClient, admin_token: str, test_asset: dict):
+    """Test uploading unsupported file type"""
+    files = {
+        "file": ("test.txt", BytesIO(b"not an image"), "text/plain")
+    }
+    response = client.post(
+        f"/api/admin/assets/{test_asset['id']}/pictures",
+        files=files,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 400
+    assert "Unsupported" in response.json()["detail"] or "지원" in response.json()["detail"]
+
+
+def test_upload_picture_too_large(client: TestClient, admin_token: str, test_asset: dict):
+    """Test uploading oversized image (> 5MB)"""
+    big_bytes = b"a" * (5 * 1024 * 1024 + 1)
+    files = {
+        "file": ("big.jpg", BytesIO(big_bytes), "image/jpeg")
+    }
+    response = client.post(
+        f"/api/admin/assets/{test_asset['id']}/pictures",
+        files=files,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 400
+    assert "large" in response.json()["detail"].lower() or "크" in response.json()["detail"]
+
+
+def test_upload_picture_without_auth(client: TestClient, test_asset: dict):
+    """Test uploading picture without authentication"""
+    files = {
+        "file": ("test.jpg", BytesIO(_fake_jpeg_bytes()), "image/jpeg")
+    }
+    response = client.post(
+        f"/api/admin/assets/{test_asset['id']}/pictures",
+        files=files,
+    )
+    assert response.status_code == 401
+
+
+def test_list_asset_pictures(client: TestClient, admin_token: str, test_asset: dict, uploaded_picture: dict):
+    """Test listing picture metadata for asset"""
+    response = client.get(
+        f"/api/assets/{test_asset['id']}/pictures",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code in [200, 401, 403], response.text
+
+    if response.status_code == 200:
+        data = response.json()
+        assert isinstance(data, list)
+        assert any(item.get("id") == uploaded_picture["id"] for item in data)
+
+
+def test_get_picture_binary(client: TestClient, uploaded_picture: dict):
+    """Test getting picture binary"""
+    response = client.get(f"/api/pictures/{uploaded_picture['id']}")
+    assert response.status_code == 200, response.text
+    assert response.headers.get("content-type", "").startswith("image/")
+    assert len(response.content) > 0
+
+
+def test_get_picture_not_found(client: TestClient):
+    """Test getting non-existent picture binary"""
+    response = client.get("/api/pictures/99999999")
+    assert response.status_code in [404, 422]
+
+
+def test_set_main_picture(client: TestClient, admin_token: str, test_asset: dict):
+    """Test setting main picture"""
+    # Upload two pictures (both non-main)
+    files1 = {"file": ("a.jpg", BytesIO(_fake_jpeg_bytes()), "image/jpeg")}
+    res1 = client.post(
+        f"/api/admin/assets/{test_asset['id']}/pictures",
+        files=files1,
+        params={"is_main": "false"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert res1.status_code in [201, 200], res1.text
+    pic1_id = res1.json()["id"]
+
+    files2 = {"file": ("b.jpg", BytesIO(_fake_jpeg_bytes()), "image/jpeg")}
+    res2 = client.post(
+        f"/api/admin/assets/{test_asset['id']}/pictures",
+        files=files2,
+        params={"is_main": "false"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert res2.status_code in [201, 200], res2.text
+    pic2_id = res2.json()["id"]
+
+    # Set second as main
+    response = client.patch(
+        f"/api/admin/assets/{test_asset['id']}/pictures/{pic2_id}/main",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code in [204, 200], response.text
+
+    # Verify via list (if accessible)
+    list_res = client.get(
+        f"/api/assets/{test_asset['id']}/pictures",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    if list_res.status_code != 200:
+        return
+
+    items = list_res.json()
+    pic2 = next((x for x in items if x.get("id") == pic2_id), None)
+    assert pic2 is not None
+    assert pic2.get("is_main") is True
+
+    pic1 = next((x for x in items if x.get("id") == pic1_id), None)
+    if pic1 is not None:
+        assert pic1.get("is_main") is False
+
+
+def test_delete_picture_success(client: TestClient, admin_token: str, test_asset: dict):
+    """Test deleting picture"""
+    # Upload
+    files = {"file": ("test.jpg", BytesIO(_fake_jpeg_bytes()), "image/jpeg")}
+    upload = client.post(
+        f"/api/admin/assets/{test_asset['id']}/pictures",
+        files=files,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert upload.status_code in [201, 200], upload.text
+    picture_id = upload.json()["id"]
+
+    # Delete
+    response = client.delete(
+        f"/api/admin/assets/{test_asset['id']}/pictures/{picture_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code in [204, 200], response.text
+
+    # Confirm delete (binary should be 404 or 410)
+    get_res = client.get(f"/api/pictures/{picture_id}")
+    assert get_res.status_code in [404, 410]
+
+
+def test_delete_picture_without_auth(client: TestClient, admin_token: str, test_asset: dict):
+    """Test deleting picture without authentication"""
+    # Upload with admin
+    files = {"file": ("test.jpg", BytesIO(_fake_jpeg_bytes()), "image/jpeg")}
+    upload = client.post(
+        f"/api/admin/assets/{test_asset['id']}/pictures",
+        files=files,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert upload.status_code in [201, 200], upload.text
+    picture_id = upload.json()["id"]
+
+    # Delete without auth
+    response = client.delete(
+        f"/api/admin/assets/{test_asset['id']}/pictures/{picture_id}",
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
- 자산(Picture) 이미지 업로드 기능 구현
- 이미지 바이너리 조회 API 분리 설계
- 대표 이미지 설정 기능 추가
- picture 관련 pytest 작성

※ 이미지 데이터는 LONGBLOB로 데이터베이스에 저장함