### PR TITLE
feat:사용자 구글 소셜 로그인 추가

### DIFF
--- a/asset_management/app/auth/repositories.py
+++ b/asset_management/app/auth/repositories.py
@@ -16,6 +16,9 @@ class AuthRepository:
     
     def get_user_by_email(self, email: str) -> User | None:
         return self.db_session.query(User).filter(User.email == email).first()
+
+    def get_user_by_social_email(self, email: str) -> User | None:
+        return self.db_session.query(User).filter(User.social_email == email).first()
     
     def add_refresh_token(self, token: str, user_id: str, expires_at) -> None:
       refresh_token = RefreshToken(

--- a/asset_management/app/auth/router.py
+++ b/asset_management/app/auth/router.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Header, status, Response
 from sqlalchemy.orm import Session
-from asset_management.app.auth.schemas import LoginResponse, UserSignin, TokenResponse
+from asset_management.app.auth.schemas import LoginResponse, UserSignin, TokenResponse, GoogleSignin
 from asset_management.app.auth.services import AuthServices
 from asset_management.app.auth.utils import (
   issue_token,
@@ -21,6 +21,14 @@ def login(
   request: UserSignin, auth_service: Annotated[AuthServices, Depends()]
 ) -> LoginResponse:
   login_info = auth_service.login_user(request.email, request.password)
+  return LoginResponse(**login_info)
+
+
+@router.post("/google", status_code=status.HTTP_200_OK)
+def google_login(
+  request: GoogleSignin, auth_service: Annotated[AuthServices, Depends()]
+) -> LoginResponse:
+  login_info = auth_service.login_google(request.id_token)
   return LoginResponse(**login_info)
 
 

--- a/asset_management/app/auth/schemas.py
+++ b/asset_management/app/auth/schemas.py
@@ -4,9 +4,13 @@ class UserSignin(BaseModel):
     email: EmailStr
     password: str
 
+class GoogleSignin(BaseModel):
+    id_token: str
+
 class TokenResponse(BaseModel):
     access_token: str
     refresh_token: str
+
 class LoginResponse(BaseModel):
     user_name: str
     user_type: int

--- a/asset_management/app/auth/services.py
+++ b/asset_management/app/auth/services.py
@@ -1,9 +1,13 @@
 from datetime import datetime, timedelta
 from typing import Annotated
+import json
+import urllib.parse
+import urllib.request
 from asset_management.app.auth.repositories import AuthRepository
 from asset_management.app.auth.settings import AUTH_SETTINGS
 from asset_management.app.auth.utils import issue_token, verify_password, verify_token
 from fastapi import Depends, HTTPException, Header, status
+from asset_management.app.user.models import User
 
 
 class AuthServices:
@@ -29,6 +33,81 @@ class AuthServices:
     user_name = user.name
     user_type = user.is_admin
     return {"user_name": user_name, "user_type": user_type, "tokens": self.issue_token(user.id)}
+
+  def _verify_google_id_token(self, id_token: str) -> dict:
+    if not AUTH_SETTINGS.GOOGLE_CLIENT_ID:
+      raise HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="Google client ID not configured",
+      )
+
+    tokeninfo_url = "https://oauth2.googleapis.com/tokeninfo"
+    url = f"{tokeninfo_url}?id_token={urllib.parse.quote(id_token)}"
+    try:
+      with urllib.request.urlopen(url, timeout=5) as response:
+        data = json.loads(response.read().decode("utf-8"))
+    except Exception:
+      raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid Google ID token",
+      )
+
+    if data.get("aud") != AUTH_SETTINGS.GOOGLE_CLIENT_ID:
+      raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid Google token audience",
+      )
+    if data.get("email_verified") not in ["true", True]:
+      raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Google email not verified",
+      )
+    if "email" not in data:
+      raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Google email missing",
+      )
+    return data
+
+  def login_google(self, id_token: str):
+    data = self._verify_google_id_token(id_token)
+    email = data["email"]
+
+    user = self.auth_repository.get_user_by_social_email(email)
+    if not user:
+      user = self.auth_repository.get_user_by_email(email)
+
+    if user:
+      if user.is_admin:
+        raise HTTPException(
+          status_code=status.HTTP_403_FORBIDDEN,
+          detail="Admin account cannot use social login",
+        )
+      if not user.social_email:
+        user.social_email = email
+        self.auth_repository.db_session.commit()
+      return {
+        "user_name": user.name,
+        "user_type": user.is_admin,
+        "tokens": self.issue_token(user.id),
+      }
+
+    name = data.get("name") or email.split("@")[0]
+    user = User(
+      name=name,
+      email=email,
+      social_email=email,
+      hashed_password=None,
+      is_admin=False,
+    )
+    self.auth_repository.db_session.add(user)
+    self.auth_repository.db_session.commit()
+    self.auth_repository.db_session.refresh(user)
+    return {
+      "user_name": user.name,
+      "user_type": user.is_admin,
+      "tokens": self.issue_token(user.id),
+    }
 
   def refresh_user_token(self, refresh_token: str):
     user_id = verify_token(refresh_token, AUTH_SETTINGS.REFRESH_TOKEN_SECRET, "refresh")

--- a/asset_management/app/auth/settings.py
+++ b/asset_management/app/auth/settings.py
@@ -4,6 +4,7 @@ from asset_management.settings import SETTINGS
 class AuthSettings(BaseSettings):
     ACCESS_TOKEN_SECRET: str
     REFRESH_TOKEN_SECRET: str
+    GOOGLE_CLIENT_ID: str | None = None
     SHORT_SESSION_LIFESPAN: int = 15
     LONG_SESSION_LIFESPAN: int = 24 * 60
 


### PR DESCRIPTION
- POST /auth/google 추가 + ID 토큰 검증
- 일반 사용자만 허용, 관리자 차단
- 기존 이메일 계정 연결 or 신규 생성
- GOOGLE_CLIENT_ID 설정 추가
- 소셜 로그인 테스트 보강
