### PR TITLE
feat(auth): SHA-256에서 argon2로 비밀번호 해싱 전환

### DIFF
--- a/asset_management/app/auth/services.py
+++ b/asset_management/app/auth/services.py
@@ -5,7 +5,7 @@ import urllib.parse
 import urllib.request
 from asset_management.app.auth.repositories import AuthRepository
 from asset_management.app.auth.settings import AUTH_SETTINGS
-from asset_management.app.auth.utils import issue_token, verify_password, verify_token
+from asset_management.app.auth.utils import issue_token, verify_password, verify_token, needs_password_migration, hash_password
 from fastapi import Depends, HTTPException, Header, status
 from asset_management.app.user.models import User
 
@@ -30,6 +30,12 @@ class AuthServices:
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Invalid email or password",
       )
+    
+    # SHA-256에서 argon2로 점진적 마이그레이션
+    if needs_password_migration(user.hashed_password):
+      user.hashed_password = hash_password(password)
+      self.auth_repository.db_session.commit()
+    
     user_name = user.name
     user_type = user.is_admin
     return {"user_name": user_name, "user_type": user_type, "tokens": self.issue_token(user.id)}

--- a/asset_management/app/auth/utils.py
+++ b/asset_management/app/auth/utils.py
@@ -7,7 +7,12 @@ from authlib.jose.errors import JoseError
 from fastapi import Depends, Header, HTTPException, status
 from typing import Annotated
 import hashlib
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError, InvalidHashError
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+# Argon2 password hasher
+ph = PasswordHasher()
 
 
 def issue_token(user_id: int) -> str:
@@ -66,7 +71,22 @@ def refresh_token(token: Annotated[str | None, Depends(get_header_token)] = None
   return verify_token(token, AUTH_SETTINGS.REFRESH_TOKEN_SECRET, "refresh")
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-  return hashlib.sha256(plain_password.encode("utf-8")).hexdigest() == hashed_password
+  """비밀번호 검증 (argon2 및 레거시 SHA-256 지원)"""
+  # argon2 해시는 "$argon2"로 시작
+  if hashed_password.startswith("$argon2"):
+    try:
+      ph.verify(hashed_password, plain_password)
+      return True
+    except (VerifyMismatchError, InvalidHashError):
+      return False
+  else:
+    # 기존 SHA-256 (마이그레이션 대상)
+    return hashlib.sha256(plain_password.encode("utf-8")).hexdigest() == hashed_password
+
+
+def needs_password_migration(hashed_password: str) -> bool:
+  """비밀번호가 argon2로 마이그레이션이 필요한지 확인"""
+  return not hashed_password.startswith("$argon2")
 
 def check_club_permission(user_club_id: int, resource_club_id: int, auth_repository: Annotated[AuthRepository, Depends()]) -> int:
   """Check if the user has permission for the club resource.
@@ -92,7 +112,7 @@ def check_club_permission(user_club_id: int, resource_club_id: int, auth_reposit
   return userclubinfo.permission
 
 def hash_password(password: str) -> str:
-  """Hash the password using SHA-256.
+  """Hash the password using Argon2.
   
   Args:
       password (str): The plain text password.
@@ -100,4 +120,4 @@ def hash_password(password: str) -> str:
   Returns:
       str: The hashed password.
   """
-  return hashlib.sha256(password.encode("utf-8")).hexdigest()
+  return ph.hash(password)

--- a/asset_management/app/user/routes.py
+++ b/asset_management/app/user/routes.py
@@ -1,18 +1,12 @@
-import hashlib
-
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from asset_management.app.user.models import User
 from asset_management.app.user.schemas import UserCreate, UserResponse
+from asset_management.app.auth.utils import hash_password
 from asset_management.database.session import get_session
 
 router = APIRouter(prefix="/users", tags=["users"])
-
-
-def _hash_password(raw_password: str) -> str:
-    # Simple SHA-256 hash; replace with stronger hashing (bcrypt/argon2) in production.
-    return hashlib.sha256(raw_password.encode("utf-8")).hexdigest()
 
 
 @router.post(
@@ -32,7 +26,7 @@ def signup(payload: UserCreate, session: Session = Depends(get_session)):
     user = User(
         name=payload.name,
         email=payload.email,
-        hashed_password=_hash_password(payload.password),
+        hashed_password=hash_password(payload.password),
     )
     session.add(user)
     session.commit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "sqlalchemy-pagination>=0.0.2",
     "python-multipart>=0.0.21",
     "openpyxl>=3.1.0",
+    "argon2-cffi>=25.1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -78,7 +78,8 @@ def test_signup_success(client, db_session):
     with db_session() as session:
         user = session.query(User).filter(User.email == payload["email"]).one()
         assert user.hashed_password != payload["password"]
-        assert len(user.hashed_password) == 64
+        # argon2 해시는 "$argon2"로 시작함
+        assert user.hashed_password.startswith("$argon2")
 
 
 def test_signup_conflict_email(client):

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "23-5-team6-server"
@@ -9,6 +13,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiomysql" },
     { name = "alembic" },
+    { name = "argon2-cffi" },
     { name = "authlib" },
     { name = "email-validator" },
     { name = "fastapi" },
@@ -36,6 +41,7 @@ requires-dist = [
     { name = "aiomysql", specifier = ">=0.3.2" },
     { name = "aiosqlite", marker = "extra == 'dev'", specifier = ">=0.20.0" },
     { name = "alembic", specifier = ">=1.17.2" },
+    { name = "argon2-cffi", specifier = ">=25.1.0" },
     { name = "authlib", specifier = ">=1.6.6" },
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
@@ -118,6 +124,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/ce/8a777047513153587e5434fd752e89334ac33e379aa3497db860eeb60377/anyio-4.12.0.tar.gz", hash = "sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0", size = 228266, upload-time = "2025-11-28T23:37:38.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl", hash = "sha256:dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb", size = 113362, upload-time = "2025-11-28T23:36:57.897Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- argon2-cffi 의존성 추가
- auth/utils.py에 argon2 해싱 함수 구현
- verify_password에서 argon2와 레거시 SHA-256 모두 지원
- 로그인 시 SHA-256 → argon2 점진적 마이그레이션 구현
- user/routes.py에서 중복 해시 함수 제거, auth/utils 사용
- test_signup.py에서 argon2 해시 형식 검증으로 변경

신규 사용자는 argon2 해시로 저장됨
기존 SHA-256 사용자는 로그인 시 자동 마이그레이션