### PR TITLE
fix: 반납 사진, 관리자 자산 작업, 통계 갱신 조건 로직 수정

### DIFF
--- a/asset_management/app/admin/routes.py
+++ b/asset_management/app/admin/routes.py
@@ -359,6 +359,11 @@ def add_asset(
         UserClublist.user_id == current_user.id,
         UserClublist.permission == UserPermission.ADMIN.value
     ).first()
+    if not admin_club:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Admin club not found"
+        )
 
     return asset_service.create_asset_for_admin(admin_club.club_id, asset)
     
@@ -383,6 +388,11 @@ def update_asset(
         UserClublist.user_id == current_user.id,
         UserClublist.permission == UserPermission.ADMIN.value
     ).first()
+    if not admin_club:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Admin club not found"
+        )
 
     return asset_service.update_asset_for_admin(admin_club.club_id, asset_id, asset)
 
@@ -391,6 +401,7 @@ def delete_asset(
     asset_id: int,
     current_user: Annotated[User, Depends(get_current_user)],
     asset_service: Annotated[AssetService, Depends()],
+    session: Session = Depends(get_session),
 ):
     # Check if user is admin
     if not current_user.is_admin:
@@ -398,9 +409,18 @@ def delete_asset(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required"
         )
-    
-    
-    return asset_service.delete_asset_for_admin(asset_id)
+    # Get admin's club
+    admin_club = session.query(UserClublist).filter(
+        UserClublist.user_id == current_user.id,
+        UserClublist.permission == UserPermission.ADMIN.value
+    ).first()
+    if not admin_club:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Admin club not found"
+        )
+
+    return asset_service.delete_asset_for_admin(admin_club.club_id, asset_id)
 
 
 @router.post("/assets/{asset_id}/pictures", status_code=status.HTTP_201_CREATED)

--- a/asset_management/app/assets/services.py
+++ b/asset_management/app/assets/services.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from io import StringIO, BytesIO
 from typing import Annotated, List
 
-from fastapi import Depends, UploadFile
+from fastapi import Depends, UploadFile, HTTPException, status
 from openpyxl import Workbook, load_workbook
 from openpyxl.utils import get_column_letter
 from asset_management.app.assets.repositories import AssetRepository
@@ -56,7 +56,15 @@ class AssetService:
         
         asset = self.asset_repository.get_asset_by_id(asset_id)
         if asset is None:
-            raise Exception("ItemNotFoundException")  # Replace with proper exception
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Asset not found",
+            )
+        if asset.club_id != admin_club_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permission denied",
+            )
 
         updated_asset = self.asset_repository.modify_asset(
             asset,
@@ -84,11 +92,19 @@ class AssetService:
             max_rental_days=updated_asset.max_rental_days,
         )
 
-    def delete_asset_for_admin(self, asset_id: int) -> None:
+    def delete_asset_for_admin(self, admin_club_id: int, asset_id: int) -> None:
 
         asset = self.asset_repository.get_asset_by_id(asset_id)
         if asset is None:
-            raise Exception("ItemNotFoundException")  # Replace with proper exception
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Asset not found",
+            )
+        if asset.club_id != admin_club_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permission denied",
+            )
         
         self.asset_repository.delete_asset(asset)
 

--- a/asset_management/app/rental/services.py
+++ b/asset_management/app/rental/services.py
@@ -215,18 +215,21 @@ class RentalService:
         
 
         try:
-            new_picture = Picture(
-                asset_id=schedule.asset_id,
-                is_main=False,
-                user_id=user_id,
-                data=data,
-                content_type=file.content_type if file is not None else None,
-                filename=file.filename if file is not None else "upload",
-                size=len(data) if data is not None else 0            
-            )
+            return_picture_id = None
+            if file is not None:
+                new_picture = Picture(
+                    asset_id=schedule.asset_id,
+                    is_main=False,
+                    user_id=user_id,
+                    data=data,
+                    content_type=file.content_type,
+                    filename=file.filename or "upload",
+                    size=len(data) if data is not None else 0,
+                )
 
-            self.db_session.add(new_picture)
-            self.db_session.flush()
+                self.db_session.add(new_picture)
+                self.db_session.flush()
+                return_picture_id = new_picture.id
 
             # 낙관적 락으로 반납 상태 업데이트
             result = self.db_session.execute(
@@ -239,7 +242,7 @@ class RentalService:
                 .values(
                     status=Status.RETURNED.value,
                     end_date=returned_at,
-                    return_picture_id=new_picture.id if file is not None else None
+                    return_picture_id=return_picture_id,
                     )
             )
 

--- a/asset_management/app/statistics/services.py
+++ b/asset_management/app/statistics/services.py
@@ -19,7 +19,7 @@ class StatisticsService:
     if statistics is None:
       self.statistics_repository.create(asset_id)
       statistics = self.update_statistics_for_asset(asset_id)
-    if statistics.last_updated_at > datetime.now() + timedelta(days=3):
+    if statistics.last_updated_at < datetime.now() - timedelta(days=3):
       statistics = self.update_statistics_for_asset(asset_id)
 
     return AssetStatistics.model_validate(statistics)


### PR DESCRIPTION
- 반납 시 사진이 없을 때 500 오류 발생
return_item에서 파일이 없으면 Picture를 생성하지 않도록 수정해, 사진 없이도 정상 반납

- 관리자 자산 작업이 타 클럽 자산에도 가능했던 문제
관리자 자산 수정/삭제 시 해당 자산이 관리자 소속 클럽에 속하는지 검증하도록 추가
관리자 클럽 정보가 없을 경우 404를 반환하도록 방어 처리

- 통계 자동 갱신 조건 반전 오류
last_updated_at이 3일 이상 경과했을 때 갱신되도록 조건 수정